### PR TITLE
style: set sourcekit indentation to 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.swift]
+indent_style = space
+indent_size = 2
+tab_width = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
Basically fixes the issue I faced about sourcekit as a linter and formater in lspconfig (xcode as well i guess)\
It defaults to 4 spaces and make `:noa` you go to option :(