### PR TITLE
build: enforce swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,4 +10,5 @@ let package = Package(
   products: [.executable(name: appName, targets: [appName])],
   dependencies: [],
   targets: [.executableTarget(name: appName, dependencies: [])]
+  swiftLanguageModes: [.v6],
 )


### PR DESCRIPTION
i guess why not if there are already some MainActors and it compiles fine